### PR TITLE
Do not duplicate logs in -dry-run mode

### DIFF
--- a/bin/linz_bde_uploader.pl
+++ b/bin/linz_bde_uploader.pl
@@ -167,7 +167,8 @@ try
     my $layout = Log::Log4perl::Layout::PatternLayout->new("%d %p> %F{1}:%L - %m%n");
     if ($dry_run)
     {
-        Log::Log4perl->easy_init($INFO);
+        Log::Log4perl->easy_init( { level    => $INFO,
+                                    file     => "STDOUT" } );
         $logger = get_logger("");
     }
     else
@@ -204,7 +205,7 @@ try
         }
     }
     
-    if($verbose || $dry_run)
+    if($verbose)
     {
         my $stdout_appender = Log::Log4perl::Appender->new(
             "Log::Log4perl::Appender::Screen",

--- a/t/linz_bde_uploader.t
+++ b/t/linz_bde_uploader.t
@@ -322,16 +322,28 @@ close($cfg_fh);
 # Attempts to connect to non-existing database
 
 $test->run( args => "-full -config-path ${tmpdir}/cfg1" );
-is( $test->stderr, '', 'stderr, -full -config-path and tables.conf');
-is( $test->stdout, '', 'stdout, -full -config-path and tables.conf');
-is( $? >> 8, 1, 'exit status, with -full -config-path and tables.conf' );
+is( $test->stderr, '', 'stderr, nonexistent db');
+is( $test->stdout, '', 'stdout, nonexistent db');
+is( $? >> 8, 1, 'exit status, with nonexistent db' );
 @logged = <$log_fh>;
 is( @logged, 3,
-  'logged 3 lines, -full -config-path and tables.conf' ); # WARNING: might depend on verbosity
+  'logged 3 lines, nonexistent db' ); # WARNING: might depend on verbosity
 $log = join '', @logged;
 like( $log,
   qr/ERROR.*FATAL.*database "nonexistent" does not exist.*Duration of job/ms,
-  'logfile - -full -config-path and tables.conf db');
+  'logfile - nonexistent db');
+
+# Dry run connects anyway
+
+$test->run( args => "-full -dry-run -config-path ${tmpdir}/cfg1" );
+is( $test->stderr, '', 'stderr, nonexistent db, dry-run');
+like( $test->stdout,
+  qr/FATAL.*database "nonexistent" does not exist.*Duration of job/ms,
+  'logfile - nonexistent db, dry-run');
+is( $? >> 8, 1, 'exit status, nonexistent db, dry-run');
+@logged = <$log_fh>;
+is( @logged, 0,
+  'logged 0 lines, nonexistent db, dry-run' ); # WARNING: might depend on verbosity
 
 # A configuration with .test suffix will be read by default to
 # override the main configuration


### PR DESCRIPTION
When -dry-run is specified, all logging configuration is already
replaced by a single configuration printing to console, this
change avoids adding another log Screen appender later.

Also, it changes the printing from stderr to stdout as that's what
is documented to be the destination for the similar -verbose switch.

Closes #59.

Includes testcase.

NOTE: replaces #60