### PR TITLE
Provide default for many configuration variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,14 @@ before_install:
     | tar xzf - && cd linz-bde-schema-1.0.2
   - sudo make install
   - popd
+  # Install linz_bde_copy
+  - pushd /tmp
+  - wget -q -O -
+    https://github.com/linz/linz_bde_copy/archive/1.2.1.tar.gz
+    | tar xzf - && cd linz_bde_copy-1.2.1
+  - cmake .
+  - make && sudo make install
+  - popd
 
 script:
   - ./configure

--- a/t/data/pab1.crs
+++ b/t/data/pab1.crs
@@ -12,7 +12,7 @@ COLUMN	 lin_id                         integer NULL
 COLUMN	 reversed                       char NULL
 COLUMN	 audit_id                       integer NOT NULL
 DESC
-SIZE          411453
+SIZE          562
 {CRS-DATA}
 4457326|1|29694591|Y|80401148|
 4457326|2|29694578|Y|80401149|

--- a/t/linz_bde_uploader.t
+++ b/t/linz_bde_uploader.t
@@ -335,7 +335,27 @@ like( $log,
   qr/Table 'bde.test_table' does not exist/,
   'logfile - missing test_table');
 
-# TODO: check if linz_bde_uploader can create a table, or create one
+# Change tables.conf to reference one of the existing BDE tables
+
+open($cfg_fh, ">", "${tmpdir}/tables.conf")
+  or die "Can't write ${tmpdir}/tables.conf: $!";
+print $cfg_fh <<"EOF";
+TABLE crs_parcel_bndry key=audit_id  row_tol=0.20,0.95 files test_file
+EOF
+close($cfg_fh);
+
+# This should supposedly be first successful upload
+
+$test->run( args => "-full -config-path ${tmpdir}/cfg1" );
+is( $test->stderr, '', 'stderr, success upload test_file');
+is( $test->stdout, '', 'stdout, success upload test_file');
+is( $? >> 8, 1, 'exit status, success upload test_file');
+@logged = <$log_fh>;
+#is( @logged, 4, 'logged 4 lines, success upload test_file input file' ); # WARNING: might depend on verbosity
+$log = join '', @logged;
+like( $log,
+  qr/REPLACE ME WITH SUCCESS MESSAGE/,
+  'logfile - success upload test_file');
 
 close($log_fh);
 done_testing();


### PR DESCRIPTION
Empty string for SQL hooks (#78) and empty PG connection info
parameters (would rely on libpq defaults). Default stdout logging.

Leaves out db_connection for now, as it might be dangerous.