### PR TITLE
[travis] Do not install build dependencies for the sake of testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ script:
   - make dist
   - make distcheck
   # Test building deb package
-  - git clean -dxf && dpkg-buildpackage --no-check-builddeps -b -uc -us
+  - git clean -dxf && dpkg-buildpackage -d -b -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
   - sudo apt-get install
     debhelper
     fakeroot
-    libtest-cmd-perl
-    libtest-exception-perl
   - cpanm Test::Cmd
   # Install dbpatch PostgreSQL extension
   - sudo pgxn install dbpatch
@@ -72,4 +70,4 @@ script:
   - make dist
   - make distcheck
   # Test building deb package
-  - git clean -dxf && dpkg-buildpackage -b -uc -us
+  - git clean -dxf && dpkg-buildpackage --no-check-builddeps -b -uc -us


### PR DESCRIPTION
As Travis already run the tests we know we have all dependencies,
just not installed the apt-way, no need to check