### PR TITLE
Add support for db_error_level configuration variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Key parameters to change in the `linz_bde_uploader.conf` config are:
 * ``db_connection``: The PostgreSQL connection string for setting the database
 connection string. e.g `dbname=linz_db`
 
+* ``db_error_level``: The PostgreSQL error level, can be 0 for TERSE,
+1 for DEFAULT (the default value), 2 for VERBOSE.
+See https://www.postgresql.org/docs/current/static/runtime-config-logging.html
+
 * ``bde_repository``: Set the path to the directory of BDE unload files.
 This directory should have a `level_0` and `level_5` subdirectory with child folders
 in each with the naming convention of YYYYMMDDhhmmss for each dataset

--- a/conf/linz_bde_uploader.conf
+++ b/conf/linz_bde_uploader.conf
@@ -24,6 +24,16 @@ db_connection dbname=linz_db
 db_user
 db_pwd
 
+# Database error verbosity level:
+#   0: TERSE
+#   1: DEFAULT (default value)
+#   2: VERBOSE
+#
+# See
+# https://www.postgresql.org/docs/current/static/runtime-config-logging.html
+
+db_error_level 0
+
 # Schema for the actual control functions
 
 db_schema bde_control

--- a/lib/LINZ/BdeDatabase.pm
+++ b/lib/LINZ/BdeDatabase.pm
@@ -210,7 +210,7 @@ package LINZ::BdeDatabase;
 use Log::Log4perl qw(:easy :levels get_logger);
 use fields qw{
     _connection _user _pwd _dbh _pg_server_version _startSql
-    _finishSql _startDatasetSql _endDatasetSql _dbschema _lastUploadId
+    _finishSql _startDatasetSql _endDatasetSql _errorLevel _dbschema _lastUploadId
     _overrideLocks _usetbltransaction _usedstransaction _intransaction
     _locktimeout _allowConcurrent schema uploadId stack
 };
@@ -294,6 +294,7 @@ sub new
     $self->{_usedstransaction} = $cfg->use_dataset_transaction(1) ? 1 : 0;
     $self->{_locktimeout} = $cfg->table_exclusive_lock_timeout(60)+0;
     $self->{_allowConcurrent} = $cfg->allow_concurrent_uploads(0);
+    $self->{_errorLevel} = $cfg->db_error_level('1') + 0;
 
     $self->{schema} = $cfg->bde_schema('bde');
 
@@ -314,7 +315,7 @@ sub new
             PrintError    =>0,
             PrintWarn     =>1,
             RaiseError    =>1,
-            pg_errorlevel =>2,
+            pg_errorlevel => $self->{_errorLevel},
         }
     )
        || die "Cannot connect to database\n",DBI->errstr;

--- a/t/linz_bde_uploader.t
+++ b/t/linz_bde_uploader.t
@@ -228,12 +228,33 @@ is( $test->stderr, '', 'stderr, empty db');
 is( $test->stdout, '', 'stdout, empty db');
 is( $? >> 8, 1, 'exit status, empty db');
 @logged = <$log_fh>;
-is( @logged, 7,
-  'logged 7 lines, empty db' ); # WARNING: might depend on verbosity
+is( @logged, 6,
+  'logged 6 lines, empty db' ); # WARNING: might depend on verbosity
 $log = join '', @logged;
 like( $log,
   qr/ERROR.*function bde_checkschema.*not exist.*Duration of job/ms,
   'logfile - empty db');
+
+# Set db_error_level to terse
+
+open($cfg_fh, ">>", "${tmpdir}/cfg1")
+  or die "Can't append to ${tmpdir}/cfg1: $!";
+print $cfg_fh "db_error_level 0\n";
+close($cfg_fh);
+
+# Run again, should have less lines logged now
+
+$test->run( args => "-full -config-path ${tmpdir}/cfg1" );
+is( $test->stderr, '', 'stderr, empty db (terse)');
+is( $test->stdout, '', 'stdout, empty db (terse)');
+is( $? >> 8, 1, 'exit status, empty db (terse)');
+@logged = <$log_fh>;
+is( @logged, 3,
+  'logged 3 lines, empty db (terse)' ); # WARNING: might depend on verbosity
+$log = join '', @logged;
+like( $log,
+  qr/ERROR.*function bde_checkschema.*not exist.*Duration of job/ms,
+  'logfile - empty db (terse)');
 
 # Prepare the database now
 # TODO: make this simpler, see
@@ -744,4 +765,4 @@ is( $res->[0]{'id'}, '9', 'upload[8].id' );
 is( $res->[0]{'status'}, 'C', 'upload[9].status' );
 
 close($log_fh);
-done_testing(188);
+done_testing(193);


### PR DESCRIPTION
This is to remove an hard-coded high verbosity which makes
more noise than needed. With these changes it can be configured,
and will default to TERSE.