### PR TITLE
Allow keeping temporary schema via `keep_temp_schema` option

### DIFF
--- a/sql/02-bde_control_functions.sql
+++ b/sql/02-bde_control_functions.sql
@@ -399,9 +399,13 @@ BEGIN
     WHERE
         upl_id_lock = p_upload;
 
-    -- Drop the schema used by the lock
+    -- Drop the schema used by the lock, unless asked to keep it
 
-    EXECUTE 'DROP SCHEMA IF EXISTS ' || bde_TmpSchema(p_upload) || ' CASCADE';
+    IF bde_GetOption(p_upload, 'keep_temp_schema')::bool THEN
+        RAISE NOTICE 'Keeping temporary schema % as requested by options', bde_TmpSchema(p_upload);
+    ELSE
+        EXECUTE 'DROP SCHEMA IF EXISTS ' || bde_TmpSchema(p_upload) || ' CASCADE';
+    END IF;
 END
 $body$
 LANGUAGE plpgsql;

--- a/t/linz_bde_uploader.t
+++ b/t/linz_bde_uploader.t
@@ -834,5 +834,30 @@ $res = $dbh->selectall_arrayref(
 is( $res->[0]{'id'}, '9', 'upload[8].id' );
 is( $res->[0]{'status'}, 'C', 'upload[9].status' );
 
+# Test keeping temporary schema
+
+open($cfg_fh, ">>", "${tmpdir}/cfg1")
+  or die "Can't append to ${tmpdir}/cfg1: $!";
+print $cfg_fh "db_upload_complete_sql <<EOT\n";
+print $cfg_fh "SELECT bde_control.bde_SetOption({{id}},'keep_temp_schema','yes');\n";
+print $cfg_fh "EOT\n";
+close($cfg_fh);
+
+$test->run( args => "-f -c ${tmpdir}/cfg1 -r -o" );
+is( $? >> 8, 0, 'exit status, keep_temp_schema (10)');
+is( $test->stderr, '', 'stderr, keep_temp_schema (10)' );
+is( $test->stdout, '', 'stdout, keep_temp_schema (10)' );
+@logged = <$log_fh>;
+$log = join '', @logged;
+like( $log,
+  qr/INFO - Job 10 finished successfully/,
+  'logfile - keep_temp_schema (10)');
+
+$res = $dbh->selectall_arrayref(
+  "SELECT nspname FROM pg_namespace where nspname like 'bde_upload_%'",
+  { Slice => {} });
+is( scalar @{ $res }, 1, 'kept just one temp schema (10)' );
+is( $res->[0]{'nspname'}, 'bde_upload_10', 'kept temp schema (10)' );
+
 close($log_fh);
-done_testing(203);
+done_testing(209);


### PR DESCRIPTION
For debugging purposes, users can add this configuration to set
the request to keep temporary schema, like the following:

```
db_upload_complete_sql <<EOT
SELECT bde_control.bde_SetOption({{id}},'keep_temp_schema','yes');
EOT
```

Includes automated test

See https://github.com/linz/linz-lds-bde-schema/issues/23