### PR TITLE
Update references to linz-bde-{copy,perl} after repo rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,8 +124,8 @@ before_install:
   - popd
   # Install LINZ::Bde
   - pushd /tmp
-  - wget https://github.com/linz/linz_bde_perl/archive/1.0.2.tar.gz
-  - tar xzf 1.0.2.tar.gz && cd linz_bde_perl-1.0.2
+  - wget https://github.com/linz/linz-bde-perl/archive/1.0.2.tar.gz
+  - tar xzf 1.0.2.tar.gz && cd linz-bde-perl-1.0.2
   - perl Build.PL
   - sudo env "PATH=$PATH" ./Build install
   - popd
@@ -136,11 +136,11 @@ before_install:
     | tar xzf - && cd linz-bde-schema-1.0.2
   - sudo env "PATH=$PATH" make install
   - popd
-  # Install linz_bde_copy
+  # Install linz-bde-copy
   - pushd /tmp
   - wget -q -O -
-    https://github.com/linz/linz_bde_copy/archive/1.2.1.tar.gz
-    | tar xzf - && cd linz_bde_copy-1.2.1
+    https://github.com/linz/linz-bde-copy/archive/1.2.1.tar.gz
+    | tar xzf - && cd linz-bde-copy-1.2.1
   - cmake .
   - make && sudo env "PATH=$PATH" make install
   - popd

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 database. `linz_bde_uploader` has the ability to load full and incremental table
 Landonline BDE loads, as well as manage versioning information.
 
-Refer to [LINZ::Bde](https://github.com/linz/linz_bde_perl) documentation
+Refer to [LINZ::Bde](https://github.com/linz/linz-bde-perl) documentation
 for further information about LINZ BDE files and repository format.
 
 ## Requirements
@@ -14,13 +14,13 @@ for further information about LINZ BDE files and repository format.
 * PostgreSQL 9.3 or greater
 * [postgresql-tableversion](https://github.com/linz/postgresql-tableversion)
 * [linz-bde-schema](https://github.com/linz/linz-bde-schema)
-* [bde_copy](https://github.com/linz/linz_bde_copy)
+* [bde_copy](https://github.com/linz/linz-bde-copy)
 * Perl 5.12 or greater, plus
     - DBD::Pg
     - Date::Calc
     - File::Which
     - [LINZ::Config](https://github.com/linz/linz_utils_perl)
-    - [LINZ::Bde](https://github.com/linz/linz_bde_perl)
+    - [LINZ::Bde](https://github.com/linz/linz-bde-perl)
     - IO::Zlib
     - Log::Log4perl
     - Log::Dispatch


### PR DESCRIPTION
From linz_bde_perl to linz-bde-perl
From linz_bde_copy to linz-bde-copy