### PR TITLE
Allow loading BDE data without using temporary files

### DIFF
--- a/lib/LINZ/BdeDatabase.pm
+++ b/lib/LINZ/BdeDatabase.pm
@@ -542,10 +542,19 @@ sub streamDataToTempTable
     $dbh->do($sql);
 
     # See https://metacpan.org/pod/DBD::Pg#COPY-support
+    my @buf;
     while(<$datafh>) {
+        shift(@buf) if ( @buf > 16 );
+        push (@buf, $_);
         $dbh->pg_putcopydata($_);
     }
-    $dbh->pg_putcopyend();
+    # NOTE: will throw, on error
+    try {
+        $dbh->pg_putcopyend();
+    }
+    catch {
+        die $_ . "\nLast 16 lines of sent COPY data: @buf";
+    };
 
     $self->_clearDbMessageHandler;
     return 1;

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1013,9 +1013,8 @@ sub LoadFile
         $columns = $db->selectValidColumns($tablename,$columns);
         $reader->output_fields(split(/\|/,$columns));
 
-        # Open data file
-        my $tabledatafh = $self->_OpenDataFile($dataset,$reader)
-            || die "Could not open data file";
+        # Open data file (throw on failure)
+        my $tabledatafh = $self->_OpenDataFile($dataset,$reader);
 
         # Stream data to the database
         $db->streamDataToTempTable($tablename, $tabledatafh, $columns)

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1020,25 +1020,15 @@ sub LoadFile
         # Stream data to the database
         $db->streamDataToTempTable($tablename, $tabledatafh, $columns)
             || die "Error streaming data to ",$tablename;
-        $? = 0; # $tabledatafh could be a pipe, we check comand status
-        close($tabledatafh);
-        if ($?) {
-            die "Command used to output datafile failed";
-        }
-
         DEBUG("Loaded data file into working table $tablename");
     }
     catch
     {
-        $? = 0; # $tabledatafh could be a pipe, we check comand status
-        close($tabledatafh);
-        if ($?) {
-            die "Command used to output datafile failed";
-        }
         die $_;
     }
     finally
     {
+        close($tabledatafh);
         try
         {
             $reader->close;

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1015,7 +1015,7 @@ sub LoadFile
 
         # Open data file
         my $tabledatafh = $self->_OpenDataFile($dataset,$reader)
-            || die "Coud not open data file";
+            || die "Could not open data file";
 
         # Stream data to the database
         $db->streamDataToTempTable($tablename, $tabledatafh, $columns)
@@ -1179,8 +1179,7 @@ sub _OpenDataFile
     if ( $reader->can('pipe') )
     {
         # pipe method was added in linz-bde-perl 1.1.0
-        my ($fh, $logfile) = $self->_OpenDataPipe($dataset,$reader)
-            || die ("Cannot open dataset pipe");
+        my ($fh, $logfile) = $self->_OpenDataPipe($dataset,$reader);
         # TODO: save logfile somewhere ?
         #       it'll keep being written to while
         #       streaming !

--- a/lib/LINZ/BdeUpload.pm
+++ b/lib/LINZ/BdeUpload.pm
@@ -1021,6 +1021,13 @@ sub LoadFile
         $db->streamDataToTempTable($tablename, $tabledatafh, $columns)
             || die "Error streaming data to ",$tablename;
         DEBUG("Loaded data file into working table $tablename");
+        # As $tabledatafh could be a pipe, here
+        # we check return status
+        $? = 0;
+        close($tabledatafh);
+        if ($?) {
+            die "Command used to output datafile failed";
+        }
     }
     catch
     {
@@ -1028,7 +1035,6 @@ sub LoadFile
     }
     finally
     {
-        close($tabledatafh);
         try
         {
             $reader->close;


### PR DESCRIPTION
Only skips temporary file when supported by linz-bde-perl,
which is supposed to happen from version 1.1.0 onward, see
https://github.com/linz/linz-bde-perl/pull/24

Closes #135