### PR TITLE
Remove crs_statist_area from default list of uploaded tables

### DIFF
--- a/conf/linz_bde_uploader.conf
+++ b/conf/linz_bde_uploader.conf
@@ -264,7 +264,6 @@ include_tables <<EOT
     crs_site_locality
     crs_stat_act_parcl
     crs_stat_version
-    crs_statist_area
     crs_statute
     crs_statute_action
     crs_sur_admin_area

--- a/conf/tables.conf
+++ b/conf/tables.conf
@@ -193,7 +193,7 @@ TABLE   crs_stat_act_parcl           key=audit_id    row_tol=0.20,0.95   files s
 
 TABLE   crs_stat_version             key=audit_id    row_tol=0.20,0.95   files sav3
 
-TABLE   crs_statist_area             key=id          row_tol=0.20,0.95   files stt3
+TABLE   crs_statist_area             key=id          row_tol=0.20,0.95   files stt3 # authoritative source for this data was moved to Statistics NZ in early 2016, see https://github.com/linz/linz_bde_uploader/issues/39
 
 TABLE   crs_statute                  key=id          row_tol=0.20,0.95   files ste
 


### PR DESCRIPTION
The authoritative data source moved elsewhere, document it
in the tables.conf file.
See #39