### PR TITLE
Implement _bde_GetDependentObjectSql for dependent functions

### DIFF
--- a/sql/02-bde_control_functions.sql.in
+++ b/sql/02-bde_control_functions.sql.in
@@ -2384,6 +2384,13 @@ LANGUAGE plpgsql VOLATILE;
 ALTER FUNCTION _bde_CreateIncUpdates(REGCLASS, REGCLASS, NAME)
     OWNER TO bde_dba;
 
+-- Return an array of SQL statements which can be executed
+-- to restore every object dependent on the given table
+--
+-- NOTE: currently only supports restoring functions using
+--       the given table as the type of any argument
+--
+-- {
 CREATE OR REPLACE FUNCTION _bde_GetDependentObjectSql(
     p_upload INTEGER,
     p_base regclass
@@ -2392,13 +2399,35 @@ RETURNS
     text[]
 AS
 $body$
+DECLARE
+    defs TEXT[];
+    rec RECORD;
 BEGIN
-    RETURN ARRAY[]::text[];
+
+    -- Get functions using type table as argument type
+    FOR rec IN
+        SELECT p.oid, r.rolname
+        FROM pg_depend d, pg_type t, pg_proc p, pg_roles r
+        WHERE d.refclassid = 'pg_class'::regclass
+          AND d.refobjid = p_base
+          AND d.classid = 'pg_type'::regclass
+          AND t.oid = d.objid
+          AND t.oid = ANY(p.proargtypes)
+          AND r.oid = p.proowner
+    LOOP
+        -- pg_get_functiondef includes SECURITY DEFINER
+        -- and SEARCH PATH for the function
+        defs = array_append( defs, pg_get_functiondef(rec.oid) );
+        -- Set ownership (might not be possible)
+        defs = array_append( defs, format('ALTER FUNCTION %s OWNER TO %I',
+            rec.oid::regprocedure, rec.rolname));
+    END LOOP;
+
+    RETURN defs;
 END
 $body$
-LANGUAGE plpgsql IMMUTABLE; -- pointless empty function ?
--- TODO: does this function need to be implemented ?
---       Would become STABLE then...
+LANGUAGE plpgsql STABLE;
+-- }
 
 ALTER FUNCTION _bde_GetDependentObjectSql(INTEGER, REGCLASS) OWNER TO bde_dba;
 


### PR DESCRIPTION
Restores function and ownership.

Fixes accidental drop of bde.bde_get_app_specific.
Closes #146

NOTE: lacks automated testing (as all functions in this schema)