### PR TITLE
[debian] Remove hardcoded dependency on PgSQL 9.3 packages (support 9.3-9.6)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,9 +30,9 @@ Depends: ${misc:Depends}, ${perl:Depends},
  liblinz-bde-perl,
  cifs-utils,
  perl-doc,
- postgresql-9.3,
- postgresql-client-9.3,
- postgresql-9.3-tableversion
+ postgresql-9.3 | postgresql-9.4 | postgresql-9.5 | postgresql-9.6,
+ postgresql-client-9.3 | postgresql-client-9.4 | postgresql-client-9.5 | postgresql-client-9.6,
+ postgresql-9.3-tableversion | postgresql-9.4-tableversion | postgresql-9.5-tableversion | postgresql-9.6-tableversion
 Recommends:
 Description: Programme for loading LINZ BDE files into a PostgreSQL
  database. linz_bde_uploader has the ability to load full and incremental


### PR DESCRIPTION
This patch is dropping hardcoded dependency on PgSQL 9.3 packages. Now as PgSQL 9.3 became unsupported it started to create bigger problems during deployment.